### PR TITLE
Use project short name in the perceval scava backend

### DIFF
--- a/web-dashboards/perceval-scava/perceval/backends/scava/scava.py
+++ b/web-dashboards/perceval-scava/perceval/backends/scava/scava.py
@@ -144,16 +144,17 @@ class Scava(Backend):
 
         :returns: this backend supports items resuming
         """
-        return True
+        return False
 
     @staticmethod
     def metadata_id(item):
         """Extracts the identifier from a Scava item."""
 
-        # name for a project
         if 'id' in item:
+            # the item is a metric
             mid = item['id'] + item['updated'] + item['project']
         elif 'name' in item:
+            # the item is a project
             mid = item['name']
         else:
             raise TypeError("Can not extract metadata_id from", item)
@@ -241,7 +242,8 @@ class ScavaClient(HttpClient):
         api = self.api_projects_url
         projects = self.fetch(api)
         for project in json.loads(projects):
-            if project['name'] == project_name:
+            if project_name in [project['name'], project['shortName']]:
+                # project['shortName'] is used for building the API URLs so it is the one used in general
                 updated = project['executionInformation']['lastExecuted']
 
         return updated

--- a/web-dashboards/perceval-scava/setup.py
+++ b/web-dashboards/perceval-scava/setup.py
@@ -47,7 +47,7 @@ except (IOError, ImportError):
         long_description = f.read()
 
 
-version = '0.0.2'
+version = '0.0.3'
 
 
 class TestCommand(Command):

--- a/web-dashboards/scava-metrics/scava2es.py
+++ b/web-dashboards/scava-metrics/scava2es.py
@@ -263,7 +263,7 @@ def fetch_scava(url_api_rest, project=None):
     if not project:
         # Get the list of projects and get the metrics for all of them
         for project_scava in scava.fetch():
-            scavaProject = Scava(url=url_api_rest, project=project_scava['data']['name'])
+            scavaProject = Scava(url=url_api_rest, project=project_scava['data']['shortName'])
             for enriched_metric in enrich_metrics(scavaProject.fetch()):
                 yield enriched_metric
     else:


### PR DESCRIPTION
In the URLs in the API REST the project name used is the
shortName so the perceval backend use this now in all places.