### PR TITLE
[perceval-scava] Update factoid endpoint

### DIFF
--- a/web-dashboards/perceval-scava/perceval/backends/scava/scava.py
+++ b/web-dashboards/perceval-scava/perceval/backends/scava/scava.py
@@ -266,8 +266,7 @@ class ScavaClient(HttpClient):
                 yield project_metric
 
         elif category == CATEGORY_FACTOID:
-            # Get all factoids definitions and then find the values for the current project
-            api_factoids = urijoin(self.base_url, "factoids")
+            api_factoids = urijoin(self.base_url, "/projects/p/%s/f" % project)
             factoids = json.loads(self.fetch(api_factoids))
 
             for factoid in factoids:


### PR DESCRIPTION
This code replaces the endpoint used to fetch all factoids available in SCAVA with a more efficient one that retrieves only the factoids for a given project.