### PR TITLE
Fix NewVersionMavenTransMetricProvider and NewOsgiMavenTransMetricProvider

### DIFF
--- a/metric-platform/metric-providers/org.eclipse.scava.metricprovider.historic.configuration.puppet.dependencies/src/org/eclipse/scava/metricprovider/historic/configuration/puppet/dependencies/PuppetDependenciesHistoricMetricProvider.java
+++ b/metric-platform/metric-providers/org.eclipse.scava.metricprovider.historic.configuration.puppet.dependencies/src/org/eclipse/scava/metricprovider/historic/configuration/puppet/dependencies/PuppetDependenciesHistoricMetricProvider.java
@@ -45,7 +45,7 @@ public class PuppetDependenciesHistoricMetricProvider extends AbstractHistorical
         
     @Override
     public List<String> getIdentifiersOfUses() {
-    	return Arrays.asList(PuppetDependenciesHistoricMetricProvider.class.getCanonicalName());
+    	return Arrays.asList(PuppetDependenciesTransMetricProvider.class.getCanonicalName());
     }
     
     public void setMetricProviderContext(MetricProviderContext context) {


### PR DESCRIPTION
Add finally clause to close always BufferReader in NewVersionMavenTransMetricProvider and NewOsgiMavenTransMetricProvider.
Use shortName of a project instead of its name as projectid in the api