### PR TITLE
[scava-metrics] Change ID enriched sonarqube items

### DIFF
--- a/web-dashboards/scava-metrics/sonarqube2es.py
+++ b/web-dashboards/scava-metrics/sonarqube2es.py
@@ -29,6 +29,7 @@ import argparse
 import hashlib
 import json
 import logging
+import re
 import requests
 import time
 
@@ -179,7 +180,7 @@ def enrich_metrics(sonar_metrics):
             'project': project,
             'metric_class': 'sonarqube',
             'metric_type': sonar_metric['backend_name'],
-            'metric_id': sonar_data['id'],
+            'metric_id': 'sonar_{}'.format(re.sub('\W+', '_', sonar_data['metric']).lower()),
             'metric_desc': 'Sonar ' + sonar_data['metric'],
             'metric_name': 'Sonar ' + sonar_data['metric'],
             'metric_es_value': metric_value,


### PR DESCRIPTION
This PR addresses https://github.com/crossminer/scava/issues/320. Thus it changes the ID assigned to an enriched items obtained from sonarqube. Now the ID is the string `sonar_` plus the `metric` value lowered where all not alphanumberic characters are replaced by `_`.