### PR TITLE
[dashboards] Handle `commits.topics.messages` in scava2es

### DIFF
--- a/web-dashboards/scava-metrics/scava2es.py
+++ b/web-dashboards/scava-metrics/scava2es.py
@@ -280,7 +280,7 @@ def create_item_metrics_from_linechart_series(mdata, mupdated):
                 metric['metric_es_compute'] = 'sample'
                 metric['datetime'] = sample['Date']
 
-            if mdata['series'] in sample and mdata['series'] != 'Repository':
+            if mdata['series'] in sample and mdata['series'] not in ['Repository', 'Topics']:
                 metric['metric_id'] = mdata['id'] + '_' + sample[mdata['series']]
                 metric['metric_desc'] = mdata['description'] + '(' + sample[mdata['series']] + ')',
                 metric['metric_name'] = mdata['name'] + '(' + sample[mdata['series']] + ')'


### PR DESCRIPTION
This code allows to filter the metric `commits.topics.messages`,
derived from the metric provider `org.eclipse.scava.metricprovider.historic.commits.messages.topics.CommitsMessagesTopicsHistoricMetricProvider`.
The filtering is due to the fact that the format of the datatable object is not
consistent with the other datatables, thus the scava2es fails.
An example of the datatable is provided below:
```
{
  'Date': '20180104',
  'Topics': [
       'Items from Redis'
  ],
  'Commits Messages': 2,
  'Source (Revisions)': [
      'cc83b58586da339b70d3e3275a60a6bd5ae20491',
      '68ddd8179d5a640092c177897ccc634312fd748c'
  ]
}
```